### PR TITLE
Add config check pre-requisite for service restart

### DIFF
--- a/init.sls
+++ b/init.sls
@@ -14,6 +14,14 @@ nginx:
       - pkg: nginx
       - file: /etc/nginx/nginx.conf
       - file: /etc/nginx/conf.d/*.conf
+      - module: validate-nginx-config
+
+validate-nginx-config:
+  module.wait:
+    - name: nginx.configtest
+    - watch:
+      - file: /etc/nginx/nginx.conf
+      - file: /etc/nginx/conf.d/*.conf
 
 /etc/nginx/nginx.conf:
   file.managed:


### PR DESCRIPTION
Utilizing Nginx salt module https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.nginx.html

Also tested bootstrapping on a fresh instance as sometimes modules break with unmet dependencies but in this case it works since Nginx package is installed first and then module can use it right away.