### PR TITLE
Add additional state requirements so early start of letsencrypt service is not an issue

### DIFF
--- a/letsencrypt/init.sls
+++ b/letsencrypt/init.sls
@@ -33,6 +33,8 @@ generate-dummy-cert:
       - ln -s {{ acme_certificate_dir }}/{{ domain }}/dummy.key {{ acme_certificate_dir }}/{{ domain }}/privkey.pem
       - ln -s {{ acme_certificate_dir }}/{{ domain }}/dummy.crt {{ acme_certificate_dir }}/{{ domain }}/fullchain.pem
     - creates: {{ acme_certificate_dir }}/{{ domain }}/fullchain.pem
+    - require:
+      - file: {{ acme_certificate_dir }}/{{ domain }}
 
 
 # Deploy site to answer ACME challenges
@@ -47,6 +49,7 @@ generate-dummy-cert:
       acme_challenge_dir: {{ acme_challenge_dir }}
     - require:
       - file: /etc/nginx/conf.d
+      - file: {{ acme_challenge_dir }}
 
 # Install dehydrated, bash only ACME client
 dehydrated:


### PR DESCRIPTION
For our sks formula the letsencrypt/dehydrated service starts before nginx and when nginx starts it needs the certificates to be already there since the sks specific nginx config specifies the certificate path.

Prior to this PR this would fail because salt determined to call the `service.running` function for nginx earlier in the state execution tree. With these new requirements that's no longer the case and nginx get's started last. The two additional require lines actually guard the variables used in their state declaration (three lines above in each case).