### PR TITLE
Fix order of dummy certificate creation

### DIFF
--- a/letsencrypt/init.sls
+++ b/letsencrypt/init.sls
@@ -33,6 +33,10 @@ generate-dummy-cert:
       - ln -s {{ acme_certificate_dir }}/{{ domain }}/dummy.key {{ acme_certificate_dir }}/{{ domain }}/privkey.pem
       - ln -s {{ acme_certificate_dir }}/{{ domain }}/dummy.crt {{ acme_certificate_dir }}/{{ domain }}/fullchain.pem
     - creates: {{ acme_certificate_dir }}/{{ domain }}/fullchain.pem
+    - require:
+      - file: {{ acme_certificate_dir }}/{{ domain }}
+    - require_in:
+      - validate-nginx-config
 
 
 # Deploy site to answer ACME challenges

--- a/letsencrypt/init.sls
+++ b/letsencrypt/init.sls
@@ -138,3 +138,4 @@ initial-cert-request:
     - require:
       - file: /lib/systemd/system/letsencrypt.service
       - pkg: dehydrated
+      - service: nginx


### PR DESCRIPTION
At the moment initial state rollout does not work because at the time of config validation, dummy certificate and symlinks do not exist. This change would postpone validation to take place only after dummy certificates are in place and configuration is valid.