### PR TITLE
Update default config to keep up with upstream

### DIFF
--- a/letsencrypt/dehydrated.conf.jinja
+++ b/letsencrypt/dehydrated.conf.jinja
@@ -1,20 +1,29 @@
 # vim: ft=sh
 
+# Which user should dehydrated run as? This will be implicitly enforced when running as root
+#DEHYDRATED_USER=
+
+# Which group should dehydrated run as? This will be implicitly enforced when running as root
+#DEHYDRATED_GROUP=
+
 # Resolve names to addresses of IP version only. (curl)
 # supported values: 4, 6
 # default: <unset>
 IP_VERSION=4
 
-# Path to certificate authority (default: https://acme-v01.api.letsencrypt.org/directory)
-#CA="https://acme-v01.api.letsencrypt.org/directory"
+# URL to certificate authority or internal preset
+# Presets: letsencrypt, letsencrypt-test, zerossl, buypass, buypass-test
+# default: letsencrypt
+#CA="letsencrypt"
 
-# Path to certificate authority license terms redirect (default: https://acme-v01.api.letsencrypt.org/terms)
-#CA_TERMS="https://acme-v01.api.letsencrypt.org/terms"
+# Path to old certificate authority
+# Set this value to your old CA value when upgrading from ACMEv1 to ACMEv2 under a different endpoint.
+# If dehydrated detects an account-key for the old CA it will automatically reuse that key
+# instead of registering a new one.
+# default: https://acme-v01.api.letsencrypt.org/directory
+#OLDCA="https://acme-v01.api.letsencrypt.org/directory"
 
-# Path to license agreement (default: <unset>)
-#LICENSE=""
-
-# Which challenge should be used? Currently http-01 and dns-01 are supported
+# Which challenge should be used? Currently http-01, dns-01 and tls-alpn-01 are supported
 #CHALLENGETYPE="http-01"
 
 # Path to a directory containing additional config files, allowing to override
@@ -22,6 +31,11 @@ IP_VERSION=4
 # in this directory needs to be named with a '.sh' ending.
 # default: <unset>
 #CONFIG_D=
+
+# Directory for per-domain configuration files.
+# If not set, per-domain configurations are sourced from each certificates output directory.
+# default: <unset>
+#DOMAINS_D=
 
 # Base directory for account key, generated certificates and list of domains (default: $SCRIPTDIR -- uses config directory if undefined)
 #BASEDIR=$SCRIPTDIR
@@ -32,6 +46,9 @@ IP_VERSION=4
 # Output directory for generated certificates
 CERTDIR="{{ acme_certificate_dir }}"
 
+# Output directory for alpn verification certificates
+#ALPNCERTDIR="${BASEDIR}/alpn-certs"
+
 # Directory for account keys and registration information
 ACCOUNTDIR="${BASEDIR}/accounts"
 
@@ -39,10 +56,16 @@ ACCOUNTDIR="${BASEDIR}/accounts"
 WELLKNOWN="{{ acme_challenge_dir }}"
 
 # Default keysize for private keys (default: 4096)
-KEYSIZE=4096
+KEYSIZE="4096"
 
 # Path to openssl config file (default: <unset> - tries to figure out system default)
 #OPENSSL_CNF=
+
+# Path to OpenSSL binary (default: "openssl")
+#OPENSSL="openssl"
+
+# Extra options passed to the curl binary (default: <unset>)
+#CURL_OPTS=
 
 # Program or function called in certain situations
 #
@@ -62,7 +85,7 @@ HOOK="{{ hook }}"
 #HOOK_CHAIN="no"
 
 # Minimum days before expiration to automatically renew certificate (default: 30)
-RENEW_DAYS=30
+RENEW_DAYS="30"
 
 # Regenerate private keys instead of just signing new certificates on renewal (default: yes)
 PRIVATE_KEY_RENEW="yes"
@@ -71,7 +94,7 @@ PRIVATE_KEY_RENEW="yes"
 #PRIVATE_KEY_ROLLOVER="no"
 
 # Which public key algorithm should be used? Supported: rsa, prime256v1 and secp384r1
-#KEY_ALGO=rsa
+KEY_ALGO=rsa
 
 # E-mail to use during the registration (default: <unset>)
 CONTACT_EMAIL="{{ contact_email }}"
@@ -81,3 +104,21 @@ CONTACT_EMAIL="{{ contact_email }}"
 
 # Option to add CSR-flag indicating OCSP stapling to be mandatory (default: no)
 OCSP_MUST_STAPLE="no"
+
+# Fetch OCSP responses (default: no)
+#OCSP_FETCH="no"
+
+# OCSP refresh interval (default: 5 days)
+#OCSP_DAYS=5
+
+# Issuer chain cache directory (default: $BASEDIR/chains)
+#CHAINCACHE="${BASEDIR}/chains"
+
+# Automatic cleanup (default: no)
+#AUTO_CLEANUP="no"
+
+# ACME API version (default: auto)
+#API=auto
+
+# Preferred issuer chain (default: <unset> -> uses default chain)
+#PREFERRED_CHAIN=


### PR DESCRIPTION
Upstream example config has been updated to reflect new defaults like use of acme-v02 api: https://github.com/dehydrated-io/dehydrated/blob/master/docs/examples/config

More: https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578