### PR TITLE
Make CA configurable for dehydrated

### DIFF
--- a/letsencrypt/dehydrated.conf.jinja
+++ b/letsencrypt/dehydrated.conf.jinja
@@ -14,7 +14,7 @@ IP_VERSION=4
 # URL to certificate authority or internal preset
 # Presets: letsencrypt, letsencrypt-test, zerossl, buypass, buypass-test
 # default: letsencrypt
-#CA="letsencrypt"
+CA="{{ ca }}"
 
 # Path to old certificate authority
 # Set this value to your old CA value when upgrading from ACMEv1 to ACMEv2 under a different endpoint.

--- a/letsencrypt/init.sls
+++ b/letsencrypt/init.sls
@@ -6,6 +6,7 @@ include:
 {% set acme_certificate_dir = salt['pillar.get']('letsencrypt:acme_certificate_dir', '/etc/ssl/acme/certs') %}
 {% set domain = salt['pillar.get']('letsencrypt:domain', grains['fqdn']) %}
 {% set altnames = salt['pillar.get']('letsencrypt:altnames', '') %}
+{% set ca = salt['pillar.get']('letsencrypt:ca', 'letsencrypt') %}
 
 {% for dir in [acme_challenge_dir, acme_certificate_dir, "{}/{}".format(acme_certificate_dir, domain)] %}
 {{ dir }}:
@@ -68,6 +69,7 @@ dehydrated:
       acme_challenge_dir: {{ acme_challenge_dir }}
       contact_email: {{ contact_email }}
       hook: /etc/dehydrated/hook.sh
+      ca: {{ ca }}
   cmd.run:
     - name: /usr/bin/dehydrated --register --accept-terms
     - onchanges:

--- a/pillar.example
+++ b/pillar.example
@@ -11,3 +11,8 @@ letsencrypt:
   # NOTE: restart is used instead of reload, because nginx apparently doesn't reload
   #       certificates upon reload
   services: [nginx]
+
+  # Define CA to be used, helpful to choose stagig letsencrypt CA or other CAs for testing
+  # Possible options: letsencrypt, letsencrypt-test, zerossl, buypass, buypass-test
+  # https://github.com/dehydrated-io/dehydrated/blob/master/docs/examples/config#L24
+  ca: letsencrypt


### PR DESCRIPTION
This can be helpful to implement tests and avoiding rate limits with production environment of letsencrypt. 