### PR TITLE
Fix nginx systemd unit start

### DIFF
--- a/init.sls
+++ b/init.sls
@@ -50,7 +50,7 @@ validate-nginx-config:
     - require:
       - pkg: nginx
 
-# Ensure cache directory exists
+# Ensure cache directory exists to be read for systemd hardening using ReadWritePaths
 /var/cache/nginx:
   file.directory:
     - name: /var/cache/nginx

--- a/init.sls
+++ b/init.sls
@@ -15,6 +15,8 @@ nginx:
       - file: /etc/nginx/nginx.conf
       - file: /etc/nginx/conf.d/*.conf
       - module: validate-nginx-config
+    - require:
+      - cmd: systemctl daemon-reload
 
 validate-nginx-config:
   module.wait:
@@ -48,6 +50,16 @@ validate-nginx-config:
     - require:
       - pkg: nginx
 
+# Ensure cache directory exists
+/var/cache/nginx:
+  file.directory:
+    - name: /var/cache/nginx
+    - user: root
+    - group: root
+    - mode: 640
+    - require:
+      - pkg: nginx
+
 # Deploy hardened systemd service
 /etc/systemd/system/nginx.service.d/service.conf:
   file.managed:
@@ -58,6 +70,7 @@ validate-nginx-config:
     - source: salt://{{ slspath }}/nginx.service
     - require:
       - pkg: nginx
+      - file: /var/cache/nginx
   cmd.run:
     - name: systemctl daemon-reload
     - onchanges:


### PR DESCRIPTION
Debug info: https://github.com/vin01/salt-nginx/actions/runs/3824957146/jobs/6507552242#step:5:275

It does not occur if nginx is started first and then systemd unit is reloaded because a nginx start automatically creates cache directory. However this is a bit unpredictable and it is better to just make sure cache directory is present in advance before systemd unit is reloaded and then service is started.