### PR TITLE
Add catch all default_server

### DIFF
--- a/letsencrypt/default_server.nginx.jinja
+++ b/letsencrypt/default_server.nginx.jinja
@@ -1,5 +1,5 @@
-# default servers for nginx
-# this vHosts will catch all request that are not match an other vHosts server_name.
+# To prevent host header injection, this file sets the default_server directive and returns
+# HTTP 400 for requests with an unknown hostname in Host header
 server {
     listen *:80    default_server;
     listen [::]:80 default_server;

--- a/letsencrypt/default_server.nginx.jinja
+++ b/letsencrypt/default_server.nginx.jinja
@@ -1,0 +1,32 @@
+# default servers for nginx
+# this vHosts will catch all request that are not match an other vHosts server_name.
+server {
+    listen *:80    default_server;
+    listen [::]:80 default_server;
+    return 301 https://{{ fqdn }}$request_uri;
+}
+
+server {
+    listen *:443 default_server;
+    listen [::]:443 default_server;
+
+    ssl_protocols TLSv1.3;
+    ssl_session_cache 'shared:SSL:10m';
+    ssl_prefer_server_ciphers on;
+    ssl_stapling off;
+    ssl_stapling_verify off;
+    ssl_session_tickets off;
+
+    # Security headers
+    add_header X-Content-Type-Options $x_content_type_options;
+    add_header X-Frame-Options $x_frame_options;
+    add_header X-Robots-Tag $x_robots_tag;
+    add_header Referrer-Policy $referrer_policy;
+
+    # SSL certificate
+    ssl_dhparam {{ acme_certificate_dir }}/dhparam.pem;
+    ssl_certificate {{ acme_certificate_dir }}/{{ fqdn }}/fullchain.pem;
+    ssl_certificate_key {{ acme_certificate_dir }}/{{ fqdn }}/privkey.pem;
+
+    return 301 https://{{ fqdn }}$request_uri;
+}

--- a/letsencrypt/default_server.nginx.jinja
+++ b/letsencrypt/default_server.nginx.jinja
@@ -3,30 +3,18 @@
 server {
     listen *:80    default_server;
     listen [::]:80 default_server;
-    return 301 https://{{ fqdn }}$request_uri;
+
+    return 400 "Unknown Host $host\n";
 }
 
 server {
     listen *:443 default_server;
     listen [::]:443 default_server;
 
-    ssl_protocols TLSv1.3;
-    ssl_session_cache 'shared:SSL:10m';
-    ssl_prefer_server_ciphers on;
-    ssl_stapling off;
-    ssl_stapling_verify off;
-    ssl_session_tickets off;
-
-    # Security headers
-    add_header X-Content-Type-Options $x_content_type_options;
-    add_header X-Frame-Options $x_frame_options;
-    add_header X-Robots-Tag $x_robots_tag;
-    add_header Referrer-Policy $referrer_policy;
-
     # SSL certificate
     ssl_dhparam {{ acme_certificate_dir }}/dhparam.pem;
     ssl_certificate {{ acme_certificate_dir }}/{{ fqdn }}/fullchain.pem;
     ssl_certificate_key {{ acme_certificate_dir }}/{{ fqdn }}/privkey.pem;
 
-    return 301 https://{{ fqdn }}$request_uri;
+    return 400 "Unknown Host $host\n";
 }

--- a/letsencrypt/init.sls
+++ b/letsencrypt/init.sls
@@ -54,6 +54,20 @@ generate-dummy-cert:
     - require:
       - file: /etc/nginx/conf.d
 
+# Deploy default server
+/etc/nginx/conf.d/default_server.conf:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 644
+    - source: salt://{{ tpldir }}/default_server.nginx.jinja
+    - template: jinja
+    - defaults:
+      fqdn: {{ domain }}
+      acme_certificate_dir: {{ acme_certificate_dir }}
+    - require:
+      - file: /etc/nginx/conf.d
+
 # Install dehydrated, bash only ACME client
 dehydrated:
   pkg.installed: []


### PR DESCRIPTION
I added a default server, which will catch all request where the host header not match other servers. The default server will return a 301 redirect to https://{{ FQDN }}$request_uri.

This setup is useful to not pass faked host header to upstream server.

If an existing virtual server in nginx is already configured as default_server. Nginx will not start anymore, because nginx can only have one server which is labeled as default_server.