### PR TITLE
Add ssl default settings in http context.

### DIFF
--- a/.salt-lint
+++ b/.salt-lint
@@ -3,4 +3,3 @@ skip_list:
   # Allows 3-digit unquoted codes to still be used, such as `644` and `755`
   - 207 # File modes should always be encapsulated in quotation marks
   - 208 # File modes should always contain a leading zero
-  - 204 # Lines should be no longer than 160 chars

--- a/.salt-lint
+++ b/.salt-lint
@@ -3,3 +3,4 @@ skip_list:
   # Allows 3-digit unquoted codes to still be used, such as `644` and `755`
   - 207 # File modes should always be encapsulated in quotation marks
   - 208 # File modes should always contain a leading zero
+  - 204 # Lines should be no longer than 160 chars

--- a/.salt-lint
+++ b/.salt-lint
@@ -1,0 +1,5 @@
+---
+skip_list:
+  # Allows 3-digit unquoted codes to still be used, such as `644` and `755`
+  - 207 # File modes should always be encapsulated in quotation marks
+  - 208 # File modes should always contain a leading zero

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Install and configure nginx.
 
 Install the `nginx` package from the official PPA.
 
+Set default ssl settings in the `http` context. This settings can be overwritten in each server if needed. 
+
 To deploy sites, you need to put your configuration files in `/etc/nginx/conf.d` in another formula.
 
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install and configure nginx.
 
 Install the `nginx` package from the official PPA.
 
-Set default ssl settings in the `http` context. This settings can be overwritten in each server if needed. 
+Set default ssl settings in the `http` context. This settings can be overwritten for `server {}` block if needed. 
 
 To deploy sites, you need to put your configuration files in `/etc/nginx/conf.d` in another formula.
 

--- a/init.sls
+++ b/init.sls
@@ -50,7 +50,7 @@ validate-nginx-config:
         ssl_protocols: {{ ssl_protocols }}
         ssl_ciphers: {{ ssl_ciphers }}
         ssl_session_cache: {{ ssl_session_cache }}
-        # Quotes are needed, because yaml will interpret on/off as boolean with them.
+        # Quotes are needed, as YAML will interpret on/off as boolean
         ssl_prefer_server_ciphers: '{{ ssl_prefer_server_ciphers }}'
         ssl_stapling: '{{ ssl_stapling }}'
         ssl_stapling_verify: '{{ ssl_stapling_verify }}'

--- a/init.sls
+++ b/init.sls
@@ -1,3 +1,15 @@
+{% set ssl_protocols = salt['pillar.get']('nginx:ssl_protocols', 'TLSv1.1 TLSv1.2 TLSv1.3') %}
+{% set ssl_ciphers = salt['pillar.get']('nginx:ssl_ciphers', [
+  'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:'
+  'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-CHACHA20-POLY1305:',
+  'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256'
+]|join ) %}
+{% set ssl_session_cache = salt['pillar.get']('nginx:ssl_session_cache', 'shared:SSL:10m' ) %}
+{% set ssl_prefer_server_ciphers = salt['pillar.get']('nginx:ssl_prefer_server_ciphers', 'on') %}
+{% set ssl_stapling = salt['pillar.get']('nginx:ssl_stapling', 'off') %}
+{% set ssl_stapling_verify = salt['pillar.get']('nginx:ssl_stapling_verify', 'off') %}
+{% set ssl_session_tickets = salt['pillar.get']('nginx:ssl_session_tickets', 'off') %}
+
 nginx-repo:
   pkgrepo.managed:
     - name: deb http://nginx.org/packages/mainline/ubuntu {{ grains['oscodename'] }} nginx
@@ -33,6 +45,14 @@ validate-nginx-config:
     - user: root
     - group: root
     - mode: 644
+    - defaults:
+        ssl_protocols: {{ ssl_protocols }}
+        ssl_ciphers: {{ ssl_ciphers }}
+        ssl_session_cache: {{ ssl_session_cache }}
+        ssl_prefer_server_ciphers: {{ ssl_prefer_server_ciphers }}
+        ssl_stapling: {{ ssl_stapling }}
+        ssl_stapling_verify: {{ ssl_stapling_verify }}
+        ssl_session_tickets: {{ ssl_session_tickets }}
     - require:
       - pkg: nginx
 

--- a/init.sls
+++ b/init.sls
@@ -4,7 +4,7 @@
 # - Prefer SHA384 over SHA256
 # See: https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
 {% set ssl_protocols = salt['pillar.get']('nginx:ssl_protocols', 'TLSv1.2 TLSv1.3') %}
-{% set ssl_ciphers = salt['pillar.get']('nginx:ssl_ciphers', 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256' ) %}
+{% set ssl_ciphers = salt['pillar.get']('nginx:ssl_ciphers', 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256' ) %} # noqa: 204
 {% set ssl_session_cache = salt['pillar.get']('nginx:ssl_session_cache', 'shared:SSL:10m' ) %}
 {% set ssl_prefer_server_ciphers = salt['pillar.get']('nginx:ssl_prefer_server_ciphers', 'on') %}
 {% set ssl_stapling = salt['pillar.get']('nginx:ssl_stapling', 'off') %}

--- a/init.sls
+++ b/init.sls
@@ -4,11 +4,7 @@
 # - Prefer SHA384 over SHA256
 # See: https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
 {% set ssl_protocols = salt['pillar.get']('nginx:ssl_protocols', 'TLSv1.2 TLSv1.3') %}
-{% set ssl_ciphers = salt['pillar.get']('nginx:ssl_ciphers', [
-  'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:'
-  'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-CHACHA20-POLY1305:',
-  'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256'
-]|join ) %}
+{% set ssl_ciphers = salt['pillar.get']('nginx:ssl_ciphers', 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256' ) %}
 {% set ssl_session_cache = salt['pillar.get']('nginx:ssl_session_cache', 'shared:SSL:10m' ) %}
 {% set ssl_prefer_server_ciphers = salt['pillar.get']('nginx:ssl_prefer_server_ciphers', 'on') %}
 {% set ssl_stapling = salt['pillar.get']('nginx:ssl_stapling', 'off') %}

--- a/init.sls
+++ b/init.sls
@@ -51,9 +51,9 @@ validate-nginx-config:
         ssl_ciphers: {{ ssl_ciphers }}
         ssl_session_cache: {{ ssl_session_cache }}
         ssl_prefer_server_ciphers: {{ ssl_prefer_server_ciphers }}
-        ssl_stapling: {{ ssl_stapling }}
-        ssl_stapling_verify: {{ ssl_stapling_verify }}
-        ssl_session_tickets: {{ ssl_session_tickets }}
+        ssl_stapling: '{{ ssl_stapling }}'
+        ssl_stapling_verify: '{{ ssl_stapling_verify }}'
+        ssl_session_tickets: '{{ ssl_session_tickets }}'
     - require:
       - pkg: nginx
 

--- a/init.sls
+++ b/init.sls
@@ -1,4 +1,9 @@
-{% set ssl_protocols = salt['pillar.get']('nginx:ssl_protocols', 'TLSv1.1 TLSv1.2 TLSv1.3') %}
+# The cipher suite comes from the Mozilla TLS guide, with the following modifications:
+#  - Prefer Chacha-Poly over AES
+# - Remove less secure DHE based ciphers
+# - Prefer SHA384 over SHA256
+# See: https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+{% set ssl_protocols = salt['pillar.get']('nginx:ssl_protocols', 'TLSv1.2 TLSv1.3') %}
 {% set ssl_ciphers = salt['pillar.get']('nginx:ssl_ciphers', [
   'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:'
   'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-CHACHA20-POLY1305:',

--- a/init.sls
+++ b/init.sls
@@ -50,6 +50,7 @@ validate-nginx-config:
         ssl_protocols: {{ ssl_protocols }}
         ssl_ciphers: {{ ssl_ciphers }}
         ssl_session_cache: {{ ssl_session_cache }}
+        # Quotes are needed, because yaml will interpret on/off as boolean with them.
         ssl_prefer_server_ciphers: '{{ ssl_prefer_server_ciphers }}'
         ssl_stapling: '{{ ssl_stapling }}'
         ssl_stapling_verify: '{{ ssl_stapling_verify }}'

--- a/init.sls
+++ b/init.sls
@@ -50,7 +50,7 @@ validate-nginx-config:
         ssl_protocols: {{ ssl_protocols }}
         ssl_ciphers: {{ ssl_ciphers }}
         ssl_session_cache: {{ ssl_session_cache }}
-        ssl_prefer_server_ciphers: {{ ssl_prefer_server_ciphers }}
+        ssl_prefer_server_ciphers: '{{ ssl_prefer_server_ciphers }}'
         ssl_stapling: '{{ ssl_stapling }}'
         ssl_stapling_verify: '{{ ssl_stapling_verify }}'
         ssl_session_tickets: '{{ ssl_session_tickets }}'

--- a/letsencrypt/default_server.nginx.jinja
+++ b/letsencrypt/default_server.nginx.jinja
@@ -1,15 +1,10 @@
 # To prevent host header injection, this file sets the default_server directive and returns
 # HTTP 400 for requests with an unknown hostname in Host header
 server {
-    listen *:80    default_server;
-    listen [::]:80 default_server;
-
-    return 400 "Unknown Host $host\n";
-}
-
-server {
-    listen *:443 default_server;
-    listen [::]:443 default_server;
+    listen *:80     default_server;
+    listen [::]:80  default_server;
+    listen *:443    default_server ssl;
+    listen [::]:443 default_server ssl;
 
     # SSL certificate
     ssl_dhparam {{ acme_certificate_dir }}/dhparam.pem;

--- a/letsencrypt/init.sls
+++ b/letsencrypt/init.sls
@@ -49,8 +49,8 @@ generate-dummy-cert:
     - source: salt://{{ tpldir }}/letsencrypt.nginx.jinja
     - template: jinja
     - defaults:
-      fqdn: {{ domain }} {{ altnames }}
-      acme_challenge_dir: {{ acme_challenge_dir }}
+        fqdn: {{ domain }} {{ altnames }}
+        acme_challenge_dir: {{ acme_challenge_dir }}
     - require:
       - file: /etc/nginx/conf.d
 
@@ -63,8 +63,8 @@ generate-dummy-cert:
     - source: salt://{{ tpldir }}/default_server.nginx.jinja
     - template: jinja
     - defaults:
-      fqdn: {{ domain }}
-      acme_certificate_dir: {{ acme_certificate_dir }}
+        fqdn: {{ domain }}
+        acme_certificate_dir: {{ acme_certificate_dir }}
     - require:
       - file: /etc/nginx/conf.d
 
@@ -79,11 +79,11 @@ dehydrated:
     - source: salt://{{ tpldir }}/dehydrated.conf.jinja
     - template: jinja
     - defaults:
-      acme_certificate_dir: {{ acme_certificate_dir }}
-      acme_challenge_dir: {{ acme_challenge_dir }}
-      contact_email: {{ contact_email }}
-      hook: /etc/dehydrated/hook.sh
-      ca: {{ ca }}
+        acme_certificate_dir: {{ acme_certificate_dir }}
+        acme_challenge_dir: {{ acme_challenge_dir }}
+        contact_email: {{ contact_email }}
+        hook: /etc/dehydrated/hook.sh
+        ca: {{ ca }}
   cmd.run:
     - name: /usr/bin/dehydrated --register --accept-terms
     - onchanges:
@@ -109,7 +109,7 @@ dehydrated:
     - source: salt://{{ tpldir }}/hook.sh.jinja
     - template: jinja
     - defaults:
-      services: {{ salt['pillar.get']('letsencrypt:services', ['nginx']) }}
+        services: {{ salt['pillar.get']('letsencrypt:services', ['nginx']) }}
     - require:
       - pkg: dehydrated
 

--- a/letsencrypt/init.sls
+++ b/letsencrypt/init.sls
@@ -30,7 +30,7 @@ nginx-generate-dhparam:
 generate-dummy-cert:
   cmd.run:
     - names:
-      - openssl req -x509 -nodes -batch -newkey rsa:2048 -keyout {{ acme_certificate_dir }}/{{ domain }}/dummy.key -out {{ acme_certificate_dir }}/{{ domain }}/dummy.crt -days 1
+      - openssl req -x509 -nodes -batch -newkey rsa:2048 -keyout {{ acme_certificate_dir }}/{{ domain }}/dummy.key -out {{ acme_certificate_dir }}/{{ domain }}/dummy.crt -days 1 # noqa: 204
       - ln -s {{ acme_certificate_dir }}/{{ domain }}/dummy.key {{ acme_certificate_dir }}/{{ domain }}/privkey.pem
       - ln -s {{ acme_certificate_dir }}/{{ domain }}/dummy.crt {{ acme_certificate_dir }}/{{ domain }}/fullchain.pem
     - creates: {{ acme_certificate_dir }}/{{ domain }}/fullchain.pem

--- a/nginx.conf.jinja
+++ b/nginx.conf.jinja
@@ -24,5 +24,13 @@ http {
 
     server_tokens off;
 
+    # global TLS settings
+    ssl_protocols {{ ssl_protocols }};
+    ssl_session_cache {{ ssl_session_cache }};
+    ssl_prefer_server_ciphers {{ ssl_prefer_server_ciphers }};
+    ssl_stapling {{ ssl_stapling }};
+    ssl_stapling_verify {{ ssl_stapling_verify }};
+    ssl_session_tickets {{ ssl_session_tickets }};
+
     include /etc/nginx/conf.d/*.conf;
 }

--- a/nginx.conf.jinja
+++ b/nginx.conf.jinja
@@ -1,15 +1,4 @@
 # vim: ft=nginx
-{# This marcro is needed to revert yaml parse on or off as boolean #}
-{% macro onoff(value) -%}
-{%- if  value == 'on' or value == 'off' %} {{ abc }}
-{%- else -%}
-{% if value is sameas true or value is sameas false %}
-{%- if value %} on
-{%- else %} off
-{%- endif -%}
-{%- endif -%}
-{%- endif -%}
-{%- endmacro %}
 
 # Automatically adjust worker_processes to available CPU cores
 worker_processes {{ grains['num_cpus'] }};
@@ -39,7 +28,7 @@ http {
     ssl_protocols {{ ssl_protocols }};
     ssl_ciphers {{ ssl_ciphers }};
     ssl_session_cache {{ ssl_session_cache }};
-    ssl_prefer_server_ciphers {{ onoff(ssl_prefer_server_ciphers) }};
+    ssl_prefer_server_ciphers {{ ssl_prefer_server_ciphers }};
     ssl_stapling {{ ssl_stapling }};
     ssl_stapling_verify {{ ssl_stapling_verify }};
     ssl_session_tickets {{ ssl_session_tickets }};

--- a/nginx.conf.jinja
+++ b/nginx.conf.jinja
@@ -24,7 +24,7 @@ http {
 
     server_tokens off;
 
-    # global TLS settings
+# Global TLS settings
     ssl_protocols {{ ssl_protocols }};
     ssl_ciphers {{ ssl_ciphers }};
     ssl_session_cache {{ ssl_session_cache }};

--- a/nginx.conf.jinja
+++ b/nginx.conf.jinja
@@ -1,5 +1,5 @@
 # vim: ft=nginx
-
+{# This marcro is needed to revert yaml parse on or off as boolean #}
 {% macro onoff(value) -%}
 {%- if  value == 'on' or value == 'off' %} {{ abc }}
 {%- else -%}

--- a/nginx.conf.jinja
+++ b/nginx.conf.jinja
@@ -24,7 +24,7 @@ http {
 
     server_tokens off;
 
-# Global TLS settings
+    # Global TLS settings
     ssl_protocols {{ ssl_protocols }};
     ssl_ciphers {{ ssl_ciphers }};
     ssl_session_cache {{ ssl_session_cache }};

--- a/nginx.conf.jinja
+++ b/nginx.conf.jinja
@@ -1,5 +1,16 @@
 # vim: ft=nginx
 
+{% macro onoff(value) -%}
+{%- if  value == 'on' or value == 'off' %} {{ abc }}
+{%- else -%}
+{% if value is sameas true or value is sameas false %}
+{%- if value %} on
+{%- else %} off
+{%- endif -%}
+{%- endif -%}
+{%- endif -%}
+{%- endmacro %}
+
 # Automatically adjust worker_processes to available CPU cores
 worker_processes {{ grains['num_cpus'] }};
 user www-data;
@@ -26,11 +37,12 @@ http {
 
     # global TLS settings
     ssl_protocols {{ ssl_protocols }};
+    ssl_ciphers {{ ssl_ciphers }};
     ssl_session_cache {{ ssl_session_cache }};
-    ssl_prefer_server_ciphers {{ ssl_prefer_server_ciphers }};
-    ssl_stapling {{ ssl_stapling }};
-    ssl_stapling_verify {{ ssl_stapling_verify }};
-    ssl_session_tickets {{ ssl_session_tickets }};
+    ssl_prefer_server_ciphers {{ onoff(ssl_prefer_server_ciphers) }};
+    ssl_stapling {{ onoff(ssl_stapling) }};
+    ssl_stapling_verify {{ onoff(ssl_stapling_verify) }};
+    ssl_session_tickets {{ onoff(ssl_session_tickets) }};
 
     include /etc/nginx/conf.d/*.conf;
 }

--- a/nginx.conf.jinja
+++ b/nginx.conf.jinja
@@ -40,9 +40,9 @@ http {
     ssl_ciphers {{ ssl_ciphers }};
     ssl_session_cache {{ ssl_session_cache }};
     ssl_prefer_server_ciphers {{ onoff(ssl_prefer_server_ciphers) }};
-    ssl_stapling {{ onoff(ssl_stapling) }};
-    ssl_stapling_verify {{ onoff(ssl_stapling_verify) }};
-    ssl_session_tickets {{ onoff(ssl_session_tickets) }};
+    ssl_stapling {{ ssl_stapling }};
+    ssl_stapling_verify {{ ssl_stapling_verify }};
+    ssl_session_tickets {{ ssl_session_tickets }};
 
     include /etc/nginx/conf.d/*.conf;
 }

--- a/pillar.example
+++ b/pillar.example
@@ -5,7 +5,7 @@ nginx:
   # Default SSL values which will be written to the http context.
   # This values can be overwritten in each server context individually.
   ssl_protocols: 'TLSv1.2 TLSv1.3'
-  ssl_ciphers: 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256'
+  ssl_ciphers: 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256' # noqa: 204
 
   ssl_session_cache: 'shared:SSL:10m'
   ssl_prefer_server_ciphers: 'on'

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,20 @@
 # vim: ft=sls
 
+nginx:
+
+  # Default SSL values which will be written to the http context.
+  # This values can be overwritten in each server context individually.
+  ssl_protocols: 'TLSv1.1 TLSv1.2 TLSv1.3'
+  ssl_ciphers: 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256'
+
+  ssl_session_cache: 'shared:SSL:10m'
+  ssl_prefer_server_ciphers: 'on'
+
+  ssl_stapling: 'off'
+  ssl_stapling_verify: 'off'
+  ssl_session_tickets: 'off'
+
+
 letsencrypt:
   domain: example.com
   altnames: www.example.com alt.example.com

--- a/pillar.example
+++ b/pillar.example
@@ -4,7 +4,7 @@ nginx:
 
   # Default SSL values which will be written to the http context.
   # This values can be overwritten in each server context individually.
-  ssl_protocols: 'TLSv1.1 TLSv1.2 TLSv1.3'
+  ssl_protocols: 'TLSv1.2 TLSv1.3'
   ssl_ciphers: 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256'
 
   ssl_session_cache: 'shared:SSL:10m'

--- a/tests/integration/nginx/nginx_spec.rb
+++ b/tests/integration/nginx/nginx_spec.rb
@@ -13,7 +13,7 @@ control 'nginx' do
   describe file('/etc/nginx/nginx.conf') do
     its('mode') { should cmp '0644' }
     its('content') { should match /^\s*worker_processes/ }
-    its('content') { should match /^\s*ssl_prefer_server_ciphers:\s*on;$/ }
+    its('content') { should match /^\s*ssl_prefer_server_ciphers\s*on;$/ }
   end
 
   describe file('/etc/nginx/conf.d/default.conf') do

--- a/tests/integration/nginx/nginx_spec.rb
+++ b/tests/integration/nginx/nginx_spec.rb
@@ -13,6 +13,7 @@ control 'nginx' do
   describe file('/etc/nginx/nginx.conf') do
     its('mode') { should cmp '0644' }
     its('content') { should match /^\s*worker_processes/ }
+    its('content') { should match /^\s*ssl_prefer_server_ciphers:\s*on;$/ }
   end
 
   describe file('/etc/nginx/conf.d/default.conf') do


### PR DESCRIPTION
The ssl settings that are done in the http context used as default for
all server within the http conext. So with this new option we can manage
ssl settings in a single place. The settings can be set via pillar. If
needed the configuration values can be override in each server.

* Simplify the default_server config
* Added salt-lint config.
* Fix wrong indentation basesd on salt-lint
