### PR TITLE
Ensure dhparams are generated before config validation

### DIFF
--- a/letsencrypt/init.sls
+++ b/letsencrypt/init.sls
@@ -28,6 +28,8 @@ nginx-generate-dhparam:
     - creates: {{ acme_certificate_dir }}/dhparam.pem
     - require:
       - file: {{ acme_certificate_dir }}
+    - require_in:
+      - validate-nginx-config
 
 # Generate a self-signed dummy certificate, so nginx can start up
 generate-dummy-cert:


### PR DESCRIPTION
This was resulting in an initial failure while bootstrapping on a vanilla setup. This is hard to test but perhaps using staging API from letsencrypt, a test can be implemented as well. It is easy to miss on existing systems which use the formula.